### PR TITLE
Change RSVP user_id from uid to email

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -5,7 +5,7 @@ module EventsHelper
         if @rsvp.length == 1
             content << link_to('Change Status', edit_rsvp_path(@rsvp.first))
         else
-            content << link_to('RSVP', new_rsvp_path(:rsvp => { :user_id => current_admin.uid, :event_id => event_id, :rsvp_time => DateTime.now.utc }))
+            content << link_to('RSVP', new_rsvp_path(:rsvp => { :user_id => current_admin.email, :event_id => event_id, :rsvp_time => DateTime.now.utc }))
         end
         content.html_safe
     end

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -38,7 +38,7 @@
         <td><%= event.end_time %></td>
         <td><%= event.location %></td>
         <td><%= event.description %></td>
-        <td><%= toggle_signup_button(current_admin.uid, event.id) %></td>
+        <td><%= toggle_signup_button(current_admin.email, event.id) %></td>
         <td><%= link_to 'Show', event %></td>
         <td><%= link_to 'Edit', edit_event_path(event) %></td>
         <td><%= link_to 'Destroy', event, method: :delete, data: { confirm: 'Are you sure?' } %></td>


### PR DESCRIPTION
In order for the Attendance Report's logic to be minimized it is best if the user RSVP's with their email instead of Google's unique id.