### PR TITLE
Removing environment variables from source code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ yarn-debug.log*
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+
+config/local_env.yml

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,5 +18,12 @@ module PrcussStdioTracker
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    config.before_configuration do
+      env_file = File.join(Rails.root, 'config', 'local_env.yml')
+      YAML.load(File.open(env_file)).each do |key, value|
+        ENV[key.to_s] = value
+      end if File.exists?(env_file)
+    end
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -76,10 +76,6 @@ Rails.application.configure do
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
 
-  # Google OAuth Keys
-  ENV['GOOGLE_OAUTH_CLIENT_ID']  = '668612256365-uq3g4qq4e6c98hmo0gbj33mkajiv7cvm.apps.googleusercontent.com'
-  ENV['GOOGLE_OAUTH_CLIENT_SECRET'] = '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'
-
   # For Local Testing
   config.web_console.permissions = '172.17.0.1'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -117,8 +117,4 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
-
-  # Google OAuth Keys
-  ENV['GOOGLE_OAUTH_CLIENT_ID']  = '668612256365-uq3g4qq4e6c98hmo0gbj33mkajiv7cvm.apps.googleusercontent.com'
-  ENV['GOOGLE_OAUTH_CLIENT_SECRET'] = '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'
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -58,10 +58,6 @@ Rails.application.configure do
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 
-  # Google OAuth Keys
-  ENV['GOOGLE_OAUTH_CLIENT_ID']  = '668612256365-uq3g4qq4e6c98hmo0gbj33mkajiv7cvm.apps.googleusercontent.com'
-  ENV['GOOGLE_OAUTH_CLIENT_SECRET'] = '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'
-
   ENV["devise.mapping"] = Devise.mappings[:user]
   ENV["omniauth.auth"]  = OmniAuth.config.mock_auth[:google_oauth2]
 end


### PR DESCRIPTION
Keeping our keys secret.
Everyone will need to grab a file called "local_env.yml" from out Google Drive and put it in the "config" folder on your local copy of the repo. Otherwise, Google OAuth won't work.